### PR TITLE
Patch C char type mismatch, string interop compatibility in ffi code

### DIFF
--- a/src/date.rs
+++ b/src/date.rs
@@ -2,11 +2,11 @@ use crate::generated::apr_date_checkmask;
 use crate::time::Time;
 
 pub fn checkmask(data: &str, mask: &str) -> bool {
-    unsafe { apr_date_checkmask(data.as_ptr() as *const i8, mask.as_ptr() as *const i8) != 0 }
+    unsafe { apr_date_checkmask(data.as_ptr() as *const std::ffi::c_char, mask.as_ptr() as *const std::ffi::c_char) != 0 }
 }
 
 pub fn parse_http(data: &str) -> Option<Time> {
-    let rv = unsafe { crate::generated::apr_date_parse_http(data.as_ptr() as *const i8) };
+    let rv = unsafe { crate::generated::apr_date_parse_http(data.as_ptr() as *const std::ffi::c_char) };
     if rv == 0 {
         None
     } else {
@@ -15,7 +15,7 @@ pub fn parse_http(data: &str) -> Option<Time> {
 }
 
 pub fn parse_rfc(data: &str) -> Option<Time> {
-    let rv = unsafe { crate::generated::apr_date_parse_rfc(data.as_ptr() as *const i8) };
+    let rv = unsafe { crate::generated::apr_date_parse_rfc(data.as_ptr() as *const std::ffi::c_char) };
     if rv == 0 {
         None
     } else {

--- a/src/date.rs
+++ b/src/date.rs
@@ -2,10 +2,12 @@ use crate::generated::apr_date_checkmask;
 use crate::time::Time;
 
 pub fn checkmask(data: &str, mask: &str) -> bool {
+    let (data, mask) = (std::ffi::CString::new(data).unwrap(), std::ffi::CString::new(mask).unwrap());
     unsafe { apr_date_checkmask(data.as_ptr() as *const std::ffi::c_char, mask.as_ptr() as *const std::ffi::c_char) != 0 }
 }
 
 pub fn parse_http(data: &str) -> Option<Time> {
+    let data = std::ffi::CString::new(data).unwrap();
     let rv = unsafe { crate::generated::apr_date_parse_http(data.as_ptr() as *const std::ffi::c_char) };
     if rv == 0 {
         None
@@ -15,6 +17,7 @@ pub fn parse_http(data: &str) -> Option<Time> {
 }
 
 pub fn parse_rfc(data: &str) -> Option<Time> {
+    let data = std::ffi::CString::new(data).unwrap();
     let rv = unsafe { crate::generated::apr_date_parse_rfc(data.as_ptr() as *const std::ffi::c_char) };
     if rv == 0 {
         None

--- a/src/getopt.rs
+++ b/src/getopt.rs
@@ -177,10 +177,10 @@ impl Getopt {
     }
 
     pub fn getopt(&mut self, opts: impl IntoAllowedOptionChars) -> GetoptResult {
-        let mut opts: Vec<i8> = opts.into_iter().map(|c| c as i8).collect();
+        let mut opts: Vec<std::ffi::c_char> = opts.into_iter().map(|c| c as std::ffi::c_char).collect();
         opts.push(0);
         let mut option_ch = 0;
-        let mut option_arg: *const i8 = std::ptr::null_mut();
+        let mut option_arg: *const std::ffi::c_char = std::ptr::null_mut();
 
         let rv = unsafe {
             crate::generated::apr_getopt(
@@ -215,7 +215,7 @@ impl Getopt {
 
     pub fn getopt_long(&mut self, opts: &[Option]) -> GetoptResult {
         let mut option_ch: i32 = 0;
-        let mut option_arg: *const i8 = std::ptr::null();
+        let mut option_arg: *const std::ffi::c_char = std::ptr::null();
         let mut opts = opts
             .iter()
             .map(|o| o.as_ptr())

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -215,7 +215,7 @@ impl<'pool> Iterator for Keys<'pool> {
 pub fn hash_default(key: &[u8]) -> u32 {
     unsafe {
         let mut len = key.len() as crate::generated::apr_ssize_t;
-        crate::generated::apr_hashfunc_default(key.as_ptr() as *const i8, &mut len)
+        crate::generated::apr_hashfunc_default(key.as_ptr() as *const std::ffi::c_char, &mut len)
     }
 }
 

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -67,7 +67,7 @@ impl Pool {
     /// Set a tag for the pool.
     pub fn tag(&self, tag: &str) {
         unsafe {
-            generated::apr_pool_tag(self.0, tag.as_ptr() as *const i8);
+            generated::apr_pool_tag(self.0, tag.as_ptr() as *const std::ffi::c_char);
         }
     }
 

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -66,6 +66,7 @@ impl Pool {
 
     /// Set a tag for the pool.
     pub fn tag(&self, tag: &str) {
+        let tag = std::ffi::CString::new(tag).unwrap();
         unsafe {
             generated::apr_pool_tag(self.0, tag.as_ptr() as *const std::ffi::c_char);
         }

--- a/src/status.rs
+++ b/src/status.rs
@@ -73,7 +73,7 @@ impl Status {
             let mut buf = [0u8; 1024];
             crate::generated::apr_strerror(
                 *self as crate::generated::apr_status_t,
-                buf.as_mut_ptr() as *mut i8,
+                buf.as_mut_ptr() as *mut std::ffi::c_char,
                 buf.len(),
             );
             buf

--- a/src/time.rs
+++ b/src/time.rs
@@ -13,7 +13,7 @@ impl Time {
         let mut buf: [u8; crate::generated::APR_CTIME_LEN as usize] =
             [0; crate::generated::APR_CTIME_LEN as usize];
         unsafe {
-            crate::generated::apr_ctime(buf.as_mut_ptr() as *mut i8, self.0);
+            crate::generated::apr_ctime(buf.as_mut_ptr() as *mut std::ffi::c_char, self.0);
         }
         String::from_utf8_lossy(&buf[..])
             .trim_end_matches('\0')
@@ -24,7 +24,7 @@ impl Time {
         let mut buf: [u8; crate::generated::APR_RFC822_DATE_LEN as usize] =
             [0; crate::generated::APR_RFC822_DATE_LEN as usize];
         unsafe {
-            crate::generated::apr_rfc822_date(buf.as_mut_ptr() as *mut i8, self.0);
+            crate::generated::apr_rfc822_date(buf.as_mut_ptr() as *mut std::ffi::c_char, self.0);
         }
         String::from_utf8_lossy(&buf[..])
             .trim_end_matches('\0')

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -131,7 +131,7 @@ impl Uri {
             let hostinfo = std::ffi::CString::new(hostinfo).unwrap();
             let status = crate::generated::apr_uri_parse_hostinfo(
                 pool.as_mut_ptr(),
-                hostinfo.as_ptr() as *const i8,
+                hostinfo.as_ptr() as *const std::ffi::c_char,
                 uri as *mut _ as *mut _,
             );
             let status = crate::Status::from(status);
@@ -149,7 +149,7 @@ impl Uri {
             let url = std::ffi::CString::new(url).unwrap();
             let status = crate::generated::apr_uri_parse(
                 pool.as_mut_ptr(),
-                url.as_ptr() as *const i8,
+                url.as_ptr() as *const std::ffi::c_char,
                 uri as *mut _ as *mut _,
             );
             let status = crate::Status::from(status);
@@ -173,7 +173,7 @@ impl std::str::FromStr for Uri {
 /// Return the default port for a given scheme.
 pub fn port_of_scheme(scheme: &str) -> u16 {
     let scheme = std::ffi::CString::new(scheme).unwrap();
-    unsafe { crate::generated::apr_uri_port_of_scheme(scheme.as_ptr() as *const i8) }
+    unsafe { crate::generated::apr_uri_port_of_scheme(scheme.as_ptr() as *const std::ffi::c_char) }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Fixing mismatched C `char` type 
`apr-rs` uses `i8` wherever C chars are expected. This is not an issue on architecture with a signed char type (`x86_64`), but poses a problem on `aarch64`, `riscv64`, `s390x` and `riscv64` which use `u8` as rust's analogue to C's `char`. This package fails to build from source on `debian:sid` because of this. The bug report corresponding to this can be found [here](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1068170).

The fix suggested uses `std::ffi::c_char` which determines the architecture specific implementation of the C `char` type.

## Fixing incompatible string type in the C interface
C's string type is null terminated (`\0`), but rust's `String`, `str` and `&str` (reference to both the previous string types) types are not. The `std::ffi::CString` and `std::ffi::CStr` types are safer analogues to the default rust string types respectively and introduce error handling for edge cases where a C string cannot be used in rust due to this disparity.