### PR TITLE
refactor: extract apr-sys crate for FFI bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,10 +15,17 @@ dependencies = [
 name = "apr"
 version = "0.2.0"
 dependencies = [
- "bindgen",
+ "apr-sys",
  "ctor",
- "system-deps",
  "url",
+]
+
+[[package]]
+name = "apr-sys"
+version = "0.2.0"
+dependencies = [
+ "bindgen",
+ "system-deps",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = [".", "apr-sys"]
+
 [package]
 name = "apr"
 version = "0.2.0"
@@ -13,17 +16,12 @@ documentation = "https://docs.rs/apr"
 doctest = false
 
 [dependencies]
+apr-sys = { version = "0.2.0", path = "apr-sys" }
 ctor = "0.5"
 url = { version = "2", optional = true }
 
 [features]
 url = ["dep:url"]
-pool-debug = []
+pool-debug = ["apr-sys/pool-debug"]
 
 [build-dependencies]
-bindgen = ">=0.60"
-system-deps = "7"
-
-[package.metadata.system-deps]
-apr-1 = "*"
-"apr-util-1" = "*"

--- a/apr-sys/Cargo.toml
+++ b/apr-sys/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "apr-sys"
+version = "0.2.0"
+edition = "2021"
+authors = ["Jelmer Vernooĳ <jelmer@apache.org>"]
+repository = "https://github.com/jelmer/apr-rs.git"
+homepage = "https://github.com/jelmer/apr-rs"
+license = "Apache-2.0"
+description = "Low-level FFI bindings for Apache Portable Runtime"
+documentation = "https://docs.rs/apr-sys"
+
+[lib]
+doctest = false
+
+[dependencies]
+
+[build-dependencies]
+bindgen = ">=0.60"
+system-deps = "7"
+
+[features]
+pool-debug = []
+
+[package.metadata.system-deps]
+apr-1 = "*"
+"apr-util-1" = "*"

--- a/apr-sys/build.rs
+++ b/apr-sys/build.rs
@@ -58,7 +58,7 @@ fn create_bindings(
         .expect("Failed to generate bindings");
 
     bindings
-        .write_to_file(out_path.join("generated.rs"))
+        .write_to_file(out_path.join("bindings.rs"))
         .expect("Failed to write bindings");
 }
 

--- a/apr-sys/src/lib.rs
+++ b/apr-sys/src/lib.rs
@@ -1,0 +1,8 @@
+#![allow(bad_style)]
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(dead_code)]
+#![allow(improper_ctypes)]
+
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/src/generated.rs
+++ b/src/generated.rs
@@ -1,6 +1,1 @@
-#![allow(bad_style)]
-#![allow(non_snake_case)]
-#![allow(non_upper_case_globals)]
-#![allow(non_camel_case_types)]
-#![allow(dead_code)]
-include!(concat!(env!("OUT_DIR"), "/generated.rs"));
+pub use apr_sys::*;


### PR DESCRIPTION
Split the crate into two parts:
- apr-sys: Low-level FFI bindings generated by bindgen
- apr: Safe Rust wrapper around the FFI bindings

This separation follows Rust conventions and makes the bindings more reusable. The apr-sys crate handles all bindgen code generation while the main apr crate provides the safe API.