### PR TITLE
fix: resolve use-after-free in strmatch module

### DIFF
--- a/src/pool.rs
+++ b/src/pool.rs
@@ -126,6 +126,16 @@ impl Pool {
         }
     }
 
+    /// Allocate a C string in the pool.
+    ///
+    /// The string is copied into pool-managed memory and will live as long as the pool.
+    pub fn pstrdup(&self, s: &str) -> *const std::ffi::c_char {
+        let c_str = std::ffi::CString::new(s).expect("Invalid C string");
+        unsafe {
+            apr_sys::apr_pstrdup(self.raw, c_str.as_ptr())
+        }
+    }
+
     /// Clear all memory in the pool.
     ///
     /// This does not actually free the memory, it just allows the pool to reuse this memory for the next allocation.

--- a/src/strmatch.rs
+++ b/src/strmatch.rs
@@ -19,14 +19,13 @@ impl<'pool> StrMatch<'pool> {
     /// The pattern is compiled using an optimized algorithm (typically Boyer-Moore)
     /// for fast searching.
     pub fn new(pattern: &str, pool: &'pool Pool) -> Result<Self, crate::Error> {
-        let c_pattern = CString::new(pattern).map_err(|_| {
-            crate::Error::from_status(crate::Status::from(apr_sys::APR_EINVAL as i32))
-        })?;
+        // Allocate the pattern string in the pool to ensure it lives as long as needed
+        let c_pattern = pool.pstrdup(pattern);
 
         let compiled = unsafe {
             apr_sys::apr_strmatch_precompile(
                 pool.as_ptr() as *mut apr_sys::apr_pool_t,
-                c_pattern.as_ptr(),
+                c_pattern,
                 1, // case_sensitive
             )
         };
@@ -45,14 +44,13 @@ impl<'pool> StrMatch<'pool> {
 
     /// Precompile a case-insensitive pattern for efficient string matching.
     pub fn new_case_insensitive(pattern: &str, pool: &'pool Pool) -> Result<Self, crate::Error> {
-        let c_pattern = CString::new(pattern).map_err(|_| {
-            crate::Error::from_status(crate::Status::from(apr_sys::APR_EINVAL as i32))
-        })?;
+        // Allocate the pattern string in the pool to ensure it lives as long as needed
+        let c_pattern = pool.pstrdup(pattern);
 
         let compiled = unsafe {
             apr_sys::apr_strmatch_precompile(
                 pool.as_ptr() as *mut apr_sys::apr_pool_t,
-                c_pattern.as_ptr(),
+                c_pattern,
                 0, // case_insensitive
             )
         };


### PR DESCRIPTION
Allocate pattern strings in APR pool memory using apr_pstrdup to ensure they remain valid for the lifetime of the compiled pattern. This fixes a memory error detected by valgrind where APR was accessing freed memory.